### PR TITLE
Fix crash if prefix supplied without command

### DIFF
--- a/control/session.go
+++ b/control/session.go
@@ -300,6 +300,10 @@ func (sess *Session) RunCmd(ctx context.Context, args []string) error {
 		return nil
 	}
 
+	if len(args) == 0 {
+		return errors.New("no actual command to run")
+	}
+
 	if !actor.IsActorCmd(args) {
 		return sess.RunNonRumorCmd(ctx, args)
 	}


### PR DESCRIPTION
Calling a prefix without an actual command crashes the shell.

Minimal reproduction:

```
rumor shell
lvl_warn
```