### PR TITLE
fix status storing in cache

### DIFF
--- a/p2p/track/dstrack/status.go
+++ b/p2p/track/dstrack/status.go
@@ -36,7 +36,7 @@ func (sb *dsStatusBook) loadStatus(p peer.ID) (*beacon.Status, error) {
 		return nil, fmt.Errorf("failed parse status bytes from datastore: %v", err)
 	}
 	// cache it
-	sb.data.Store(p, status)
+	sb.data.Store(p, &status)
 	return &status, nil
 }
 


### PR DESCRIPTION
Fix #14: when a status is cached because of loading it from a previous peerstore instead of seeing it on p2p, we need to reference it by pointer instead of a full copy, to be consistent with the other store/load methods. Thanks @Cortze for the bug report